### PR TITLE
fix: misc fixes

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -27,6 +27,12 @@ abstract class Factory
     /** @var Attributes[] */
     private array $attributes;
 
+    // keep an empty constructor for BC
+    public function __construct()
+    {
+    }
+
+
     /**
      * @param Attributes $attributes
      */
@@ -38,7 +44,7 @@ abstract class Factory
 
         try {
             $factory ??= new static(); // @phpstan-ignore-line
-        } catch (\ArgumentCountError $e) { // @phpstan-ignore-line
+        } catch (\ArgumentCountError $e) {
             throw new \LogicException('Factories with dependencies (services) cannot be created before foundry is booted.', previous: $e);
         }
 

--- a/src/Mongo/MongoPersistenceStrategy.php
+++ b/src/Mongo/MongoPersistenceStrategy.php
@@ -12,7 +12,8 @@
 namespace Zenstruck\Foundry\Mongo;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Mapping\MappingException;
+use Doctrine\ODM\MongoDB\Mapping\MappingException as MongoMappingException;
+use Doctrine\Persistence\Mapping\MappingException;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Zenstruck\Foundry\Persistence\PersistenceStrategy;
 
@@ -48,7 +49,7 @@ final class MongoPersistenceStrategy extends PersistenceStrategy
     {
         try {
             $metadata = $this->objectManagerFor($owner)->getClassMetadata($object::class);
-        } catch (MappingException) {
+        } catch (MappingException|MongoMappingException) {
             return null;
         }
 

--- a/src/ORM/ORMPersistenceStrategy.php
+++ b/src/ORM/ORMPersistenceStrategy.php
@@ -14,7 +14,8 @@ namespace Zenstruck\Foundry\ORM;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
+use Doctrine\Persistence\Mapping\MappingException;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Zenstruck\Foundry\Persistence\PersistenceManager;
@@ -56,7 +57,7 @@ final class ORMPersistenceStrategy extends PersistenceStrategy
     {
         try {
             $metadata = $this->objectManagerFor($owner)->getClassMetadata($object::class);
-        } catch (MappingException) {
+        } catch (MappingException|ORMMappingException) {
             return null;
         }
 

--- a/src/Object/Instantiator.php
+++ b/src/Object/Instantiator.php
@@ -185,7 +185,9 @@ final class Instantiator
      */
     private static function namedConstructorFor(\ReflectionClass $class, string $name): \ReflectionMethod
     {
-        if (!$method = $class->getMethod($name)) {
+        try {
+            $method = $class->getMethod($name);
+        } catch (\ReflectionException) {
             throw new \LogicException(\sprintf('Named constructor "%s" for "%s" does not exist.', $name, $class->getName()));
         }
 

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -204,6 +204,10 @@ final class PersistenceManager
      */
     public function refresh(object &$object): object
     {
+        if (!$this->flush) {
+            return $object;
+        }
+
         if ($object instanceof Proxy) {
             return $object->_refresh();
         }

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -101,8 +101,8 @@ abstract class PersistentObjectFactory extends ObjectFactory
     /**
      * @final
      *
-     * @param positive-int $min
-     * @param positive-int $max
+     * @param int<0, max> $min
+     * @param int<0, max> $max
      * @param Parameters   $criteria
      *
      * @return T[]
@@ -220,6 +220,10 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
         foreach ($this->afterPersist as $callback) {
             $callback($object);
+        }
+
+        if ($this->afterPersist) {
+            $configuration->persistence()->save($object);
         }
 
         return $this->proxy($object);

--- a/src/Persistence/Proxy.php
+++ b/src/Persistence/Proxy.php
@@ -17,6 +17,7 @@ use Doctrine\Persistence\ObjectRepository;
  * @author Kevin Bond <kevinbond@gmail.com>
  *
  * @template T of object
+ * @mixin T
  */
 interface Proxy
 {

--- a/src/Persistence/RepositoryDecorator.php
+++ b/src/Persistence/RepositoryDecorator.php
@@ -173,7 +173,7 @@ final class RepositoryDecorator implements ObjectRepository, \Countable
      */
     public function randomSet(int $count, array $criteria = []): array
     {
-        if ($count < 1) {
+        if ($count < 1) { // @phpstan-ignore-line
             throw new \InvalidArgumentException(\sprintf('$number must be positive (%d given).', $count));
         }
 
@@ -181,15 +181,15 @@ final class RepositoryDecorator implements ObjectRepository, \Countable
     }
 
     /**
-     * @param positive-int $min
-     * @param positive-int $max
+     * @param int<0, max> $min
+     * @param int<0, max> $max
      * @param Parameters   $criteria
      *
      * @return T[]
      */
     public function randomRange(int $min, int $max, array $criteria = []): array
     {
-        if ($min < 1) {
+        if ($min < 0) { // @phpstan-ignore-line
             throw new \InvalidArgumentException(\sprintf('$min must be positive (%d given).', $min));
         }
 

--- a/src/Persistence/functions.php
+++ b/src/Persistence/functions.php
@@ -43,6 +43,21 @@ function persistent_factory(string $class, array|callable $attributes = []): Per
 }
 
 /**
+ * Create an anonymous "persistent with proxy" factory for the given class.
+ *
+ * @template T of object
+ *
+ * @param class-string<T>                                       $class
+ * @param array<string,mixed>|callable(int):array<string,mixed> $attributes
+ *
+ * @return PersistentProxyObjectFactory<T>
+ */
+function proxy_factory(string $class, array|callable $attributes = []): PersistentProxyObjectFactory
+{
+    return AnonymousFactoryGenerator::create($class, PersistentProxyObjectFactory::class)::new($attributes);
+}
+
+/**
  * Instantiate and "persist" the given class.
  *
  * @template T of object

--- a/src/Test/Factories.php
+++ b/src/Test/Factories.php
@@ -33,6 +33,7 @@ trait Factories
         }
 
         // integration test
+        // @phpstan-ignore-next-line
         Configuration::boot(static function() {
             if (!static::getContainer()->has('.zenstruck_foundry.configuration')) { // @phpstan-ignore-line
                 throw new \LogicException('ZenstruckFoundryBundle is not enabled. Ensure it is added to your config/bundles.php.');

--- a/src/ZenstruckFoundryBundle.php
+++ b/src/ZenstruckFoundryBundle.php
@@ -152,6 +152,7 @@ final class ZenstruckFoundryBundle extends AbstractBundle implements CompilerPas
         $this->configureFaker($config['faker'], $container);
         $this->configureGlobalState($config['global_state'], $container);
 
+        /** @var array<string, string> $bundles */
         $bundles = $container->getParameter('kernel.bundles');
 
         $configurator->import(\sprintf('../config/%s.php',

--- a/tests/Integration/Persistence/GenericFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericFactoryTestCase.php
@@ -309,18 +309,18 @@ abstract class GenericFactoryTestCase extends KernelTestCase
         $this->factory()->create(['prop1' => 'b']);
         $this->factory()->create(['prop1' => 'b']);
 
-        $range = $this->factory()::randomRange(1, 3);
+        $range = $this->factory()::randomRange(0, 3);
 
-        $this->assertGreaterThanOrEqual(1, \count($this));
+        $this->assertGreaterThanOrEqual(0, \count($this));
         $this->assertLessThanOrEqual(3, \count($this));
 
         foreach ($range as $object) {
             $this->assertContains($object->getProp1(), ['a', 'b']);
         }
 
-        $range = $this->factory()::randomRange(1, 3, ['prop1' => 'b']);
+        $range = $this->factory()::randomRange(0, 3, ['prop1' => 'b']);
 
-        $this->assertGreaterThanOrEqual(1, \count($this));
+        $this->assertGreaterThanOrEqual(0, \count($this));
         $this->assertLessThanOrEqual(3, \count($this));
 
         foreach ($range as $object) {
@@ -432,7 +432,10 @@ abstract class GenericFactoryTestCase extends KernelTestCase
         $this->factory()::repository()->assert()->empty();
 
         flush_after(function() {
-            $this->factory()::createOne();
+            $object = $this->factory()::createOne();
+
+            // ensure auto-refresh does not break when in flush_after
+            $object->getProp1();
 
             $this->factory()::repository()->assert()->empty();
         });


### PR DESCRIPTION
here are some easy fixes from the list [here](https://github.com/zenstruck/foundry/issues/516#issuecomment-1866696425)

expect some more in the coming days 😅

I really fixed the easiest stuff here:

--- 
This one fixes a major failure I have in my app:
- [x] we should catch both "persistence" and ORM/ODM `MappingException` used [here](https://github.com/kbond/foundry-next/blob/2.x/src/ORM/ORMPersistenceStrategy.php#L59) and [here](https://github.com/kbond/foundry-next/blob/2.x/src/Mongo/MongoPersistenceStrategy.php#L51) is sometimes 

---
This was one of my main problem: we need to disable autorefresh when using `flush_after()`
- [x] `flush_after()` throws the following error:
> Cannot auto refresh "App\Domain\Program" as there are unsaved changes. Be sure to call ->_save() or disable auto refreshing

---
This is a BC break, we can mitigate easily here. Moreover I think is is legit tu allow to ask "from 0 to x items"
- [x] `randomRange()` does not accept `0` anymore

---

Following ones are easy picks:
- [x] we should not forget to add an empty `Factory::__construct()`
- [x] we should add `@mixin T` in `Proxy` other wise there will be sca problems in the rare places where `Proxy` is still type-hinted
- [x] object should be saved again after `afterPersist` callbacks
- [x] `proxy_factory()` missing
