### PR TITLE
feat: improve repository decorator

### DIFF
--- a/src/Persistence/RepositoryDecorator.php
+++ b/src/Persistence/RepositoryDecorator.php
@@ -27,7 +27,7 @@ use Zenstruck\Foundry\Persistence\Exception\NotEnoughObjects;
  *
  * @phpstan-import-type Parameters from Factory
  */
-final class RepositoryDecorator implements ObjectRepository, \Countable
+final class RepositoryDecorator implements ObjectRepository, \IteratorAggregate, \Countable
 {
     /**
      * @internal
@@ -88,7 +88,7 @@ final class RepositoryDecorator implements ObjectRepository, \Countable
      */
     public function find($id): ?object
     {
-        if (\is_array($id) && !\array_is_list($id)) {
+        if (\is_array($id) && (empty($id) || !\array_is_list($id))) {
             return $this->findOneBy($id);
         }
 
@@ -249,5 +249,14 @@ final class RepositoryDecorator implements ObjectRepository, \Countable
         }
 
         return $normalized;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        if (\is_iterable($this->inner())) {
+            return yield from $this->inner();
+        }
+
+        yield from $this->findAll();
     }
 }

--- a/tests/Integration/Mongo/GenericDocumentRepositoryDecoratorTest.php
+++ b/tests/Integration/Mongo/GenericDocumentRepositoryDecoratorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Integration\Mongo;
+
+use Zenstruck\Foundry\Tests\Fixture\Factories\Document\GenericDocumentFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\GenericModelFactory;
+use Zenstruck\Foundry\Tests\Integration\Persistence\GenericRepositoryDecoratorTestCase;
+use Zenstruck\Foundry\Tests\Integration\RequiresMongo;
+
+final class GenericDocumentRepositoryDecoratorTest extends GenericRepositoryDecoratorTestCase
+{
+    use RequiresMongo;
+
+    protected function factory(): GenericModelFactory
+    {
+        return GenericDocumentFactory::new();
+    }
+}

--- a/tests/Integration/ORM/GenericEntityRepositoryDecoratorTest.php
+++ b/tests/Integration/ORM/GenericEntityRepositoryDecoratorTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Integration\ORM;
+
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericEntityFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\GenericModelFactory;
+use Zenstruck\Foundry\Tests\Integration\Persistence\GenericRepositoryDecoratorTestCase;
+use Zenstruck\Foundry\Tests\Integration\RequiresORM;
+
+final class GenericEntityRepositoryDecoratorTest extends GenericRepositoryDecoratorTestCase
+{
+    use RequiresORM;
+
+    protected function factory(): GenericModelFactory
+    {
+        return GenericEntityFactory::new();
+    }
+}

--- a/tests/Integration/Persistence/GenericRepositoryDecoratorTestCase.php
+++ b/tests/Integration/Persistence/GenericRepositoryDecoratorTestCase.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Integration\Persistence;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+use Zenstruck\Foundry\Tests\Fixture\Model\GenericModel;
+
+use function Zenstruck\Foundry\Persistence\repository;
+
+abstract class GenericRepositoryDecoratorTestCase extends KernelTestCase
+{
+    use Factories, ResetDatabase;
+
+    /**
+     * @test
+     */
+    public function repository_proxy_is_countable_and_iterable(): void
+    {
+        $this->factory()->many(4)->create();
+
+        $repository = repository($this->modelClass());
+
+        $this->assertCount(4, $repository);
+        $this->assertCount(4, \iterator_to_array($repository));
+    }
+
+    /**
+     * @test
+     */
+    public function can_fetch_objects(): void
+    {
+        $this->factory()->many(2)->create();
+
+        $repository = repository($this->modelClass());
+
+        $objects = $repository->findAll();
+        $this->assertCount(2, $objects);
+        $this->assertInstanceOf($this->modelClass(), $objects[0]);
+
+        $objects = $repository->findBy([]);
+        $this->assertCount(2, $objects);
+        $this->assertInstanceOf($this->modelClass(), $objects[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function can_call_find_with_empty_array(): void
+    {
+        $object = $this->factory()->create();
+
+        $repository = repository($this->modelClass());
+
+        $this->assertSame($object, $repository->find([]));
+    }
+
+    /**
+     * @return class-string<GenericModel>
+     */
+    protected function modelClass(): string
+    {
+        return $this->factory()::class();
+    }
+
+    /**
+     * @return PersistentObjectFactory<GenericModel>
+     */
+    abstract protected function factory(): PersistentObjectFactory;
+}


### PR DESCRIPTION
improve `RepositoryDecorator` based on

## RepositoryProxy / RepositoryDecorator
- [x] `RepositoryProxy` was iterable
- [x] `$repository->find([]);` used to not throw exceptions 

Here is something about `RepositoryDecorator` I don't know how to mititgate, and which creates hard failures in my code base:
- [ ] in 2.0, `RepositoryDecorator` only returns `T` but `RepositoryProxy` used to return `Proxy<T>`. I don't know how we should do for this? On one hand I'd prefer it to not return proxy. On the other hand, I don't know how we can deprecate this, or inform users.