### PR TITLE
feat/unit factory test

### DIFF
--- a/src/Persistence/Exception/RefreshObjectFailed.php
+++ b/src/Persistence/Exception/RefreshObjectFailed.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Persistence\Exception;
+
+final class RefreshObjectFailed extends \RuntimeException
+{
+    public static function objectNoLongExists(): static
+    {
+        return new self('object no longer exists...');
+    }
+
+    /**
+     * @param class-string $objectClass
+     */
+    public static function objectHasUnsavedChanges(string $objectClass): static
+    {
+        return new self(
+            "Cannot auto refresh \"$objectClass\" as there are unsaved changes. Be sure to call ->_save() or disable auto refreshing (see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#auto-refresh for details)."
+        );
+    }
+}

--- a/src/Persistence/IsProxy.php
+++ b/src/Persistence/IsProxy.php
@@ -13,6 +13,7 @@ namespace Zenstruck\Foundry\Persistence;
 
 use Symfony\Component\VarExporter\Internal\LazyObjectState;
 use Zenstruck\Foundry\Configuration;
+use Zenstruck\Foundry\Exception\PersistenceNotAvailable;
 use Zenstruck\Foundry\Object\Hydrator;
 
 /**
@@ -109,8 +110,14 @@ trait IsProxy
 
     private function _autoRefresh(): void
     {
-        if ($this->_autoRefresh) {
+        if (!$this->_autoRefresh) {
+            return;
+        }
+
+        try {
+            // we don't want that "transparent" calls to _refresh() to trigger a PersistenceNotAvailable
             $this->_refresh();
+        } catch (PersistenceNotAvailable) {
         }
     }
 }

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Zenstruck\Foundry\Configuration;
 use Zenstruck\Foundry\Exception\PersistenceNotAvailable;
 use Zenstruck\Foundry\ORM\ORMPersistenceStrategy;
+use Zenstruck\Foundry\Persistence\Exception\RefreshObjectFailed;
 use Zenstruck\Foundry\Tests\Fixture\TestKernel;
 
 /**
@@ -215,7 +216,7 @@ final class PersistenceManager
         $strategy = $this->strategyFor($object::class);
 
         if ($strategy->hasChanges($object)) {
-            throw new \RuntimeException(\sprintf('Cannot auto refresh "%s" as there are unsaved changes. Be sure to call ->_save() or disable auto refreshing (see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#auto-refresh for details).', $object::class));
+            throw RefreshObjectFailed::objectHasUnsavedChanges($object::class);
         }
 
         $om = $strategy->objectManagerFor($object::class);
@@ -229,7 +230,7 @@ final class PersistenceManager
         $id = $om->getClassMetadata($object::class)->getIdentifierValues($object);
 
         if (!$id || !$object = $om->find($object::class, $id)) {
-            throw new \RuntimeException('object no longer exists...');
+            throw RefreshObjectFailed::objectNoLongExists();
         }
 
         return $object;

--- a/src/Persistence/PersistentObjectFactory.php
+++ b/src/Persistence/PersistentObjectFactory.php
@@ -19,6 +19,7 @@ use Zenstruck\Foundry\Factory;
 use Zenstruck\Foundry\FactoryCollection;
 use Zenstruck\Foundry\ObjectFactory;
 use Zenstruck\Foundry\Persistence\Exception\NotEnoughObjects;
+use Zenstruck\Foundry\Persistence\Exception\RefreshObjectFailed;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -312,7 +313,7 @@ abstract class PersistentObjectFactory extends ObjectFactory
 
         try {
             return proxy($object)->_refresh()->_real();
-        } catch (\RuntimeException) {
+        } catch (PersistenceNotAvailable|RefreshObjectFailed) {
             return $object;
         }
     }

--- a/src/Test/UnitTestConfig.php
+++ b/src/Test/UnitTestConfig.php
@@ -36,8 +36,6 @@ final class UnitTestConfig
     {
         self::$instantiator = $instantiator;
         self::$faker = $faker;
-
-        Configuration::boot(self::build());
     }
 
     /**

--- a/src/Test/UnitTestConfig.php
+++ b/src/Test/UnitTestConfig.php
@@ -32,10 +32,12 @@ final class UnitTestConfig
     /**
      * @param InstantiatorCallable|null $instantiator
      */
-    public static function configure(?callable $instantiator = null, ?Faker\Generator $faker = null): void
+    public static function configure(Instantiator|callable|null $instantiator = null, ?Faker\Generator $faker = null): void
     {
         self::$instantiator = $instantiator;
         self::$faker = $faker;
+
+        Configuration::boot(self::build());
     }
 
     /**

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Unit;
+
+use Faker;
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\UnitTestConfig;
+
+use function Zenstruck\Foundry\faker;
+
+final class FactoryTest extends TestCase
+{
+    use Factories;
+
+    /**
+     * @test
+     */
+    public function can_register_custom_faker(): void
+    {
+        $defaultFaker = faker();
+        UnitTestConfig::configure(faker: Faker\Factory::create());
+
+        $this->assertNotSame(faker(), $defaultFaker);
+    }
+}

--- a/tests/Unit/FactoryTest.php
+++ b/tests/Unit/FactoryTest.php
@@ -6,10 +6,24 @@ namespace Zenstruck\Foundry\Tests\Unit;
 
 use Faker;
 use PHPUnit\Framework\TestCase;
+use Zenstruck\Foundry\Configuration;
+use Zenstruck\Foundry\Persistence\Proxy;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\UnitTestConfig;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Category\StandardCategory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Contact;
+use Zenstruck\Foundry\Tests\Fixture\Entity\GenericEntity;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\ProxyAddressFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\StandardCategoryFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\ProxyContactFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\StandardContactFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\GenericProxyEntityFactory;
+use Zenstruck\Foundry\Tests\Fixture\Object1;
 
+use function Zenstruck\Foundry\factory;
 use function Zenstruck\Foundry\faker;
+use function Zenstruck\Foundry\Persistence\proxy;
+use function Zenstruck\Foundry\Persistence\proxy_factory;
 
 final class FactoryTest extends TestCase
 {
@@ -21,8 +35,106 @@ final class FactoryTest extends TestCase
     public function can_register_custom_faker(): void
     {
         $defaultFaker = faker();
+
         UnitTestConfig::configure(faker: Faker\Factory::create());
+        Configuration::boot(UnitTestConfig::build());
 
         $this->assertNotSame(faker(), $defaultFaker);
+    }
+
+    /**
+     * @test
+     */
+    public function can_use_arrays_for_attribute_values(): void
+    {
+        $object = new class() {
+            public mixed $value;
+        };
+
+        $factory = factory($object::class)->create(['value' => ['foo' => 'bar']]);
+
+        $this->assertSame(['foo' => 'bar'], $factory->value);
+    }
+
+    /**
+     * @test
+     */
+    public function can_use_user_defined_proxy_persistent_factory_in_unit_test(): void
+    {
+        $object = GenericProxyEntityFactory::createOne();
+
+        $this->assertInstanceOf(GenericEntity::class, $object);
+        $this->assertInstanceOf(Proxy::class, $object);
+    }
+
+    /**
+     * @test
+     */
+    public function can_use_user_anonymous_proxy_persistent_factory_in_unit_test(): void
+    {
+        $object = proxy_factory(GenericEntity::class, ['prop1' => 'prop1'])->create();
+
+        $this->assertInstanceOf(GenericEntity::class, $object);
+        $this->assertInstanceOf(Proxy::class, $object);
+    }
+
+    /**
+     * @test
+     */
+    public function can_register_default_instantiator(): void
+    {
+        UnitTestConfig::configure(instantiator: static fn(): Object1 => new Object1(
+            'different prop1', 'different prop2'
+        ));
+        Configuration::boot(UnitTestConfig::build());
+
+        $object = factory(Object1::class, ['prop1' => 'prop1'])->create();
+
+        $this->assertSame('different prop1-constructor', $object->getProp1());
+        $this->assertSame('different prop2-constructor', $object->getProp2());
+    }
+
+    /**
+     * @test
+     */
+    public function proxy_attributes_can_be_used_in_unit_test(): void
+    {
+        $object = ProxyContactFactory::createOne([
+            'category' => proxy(new StandardCategory('name')),
+            'address' => ProxyAddressFactory::new(),
+        ]);
+
+        $this->assertInstanceOf(Contact::class, $object);
+    }
+
+    /**
+     * @test
+     */
+    public function instantiating_with_factory_attribute_instantiates_the_factory(): void
+    {
+        $object = StandardContactFactory::createOne([
+            'category' => StandardCategoryFactory::new(),
+        ]);
+
+        $this->assertInstanceOf(StandardCategory::class, $object->getCategory());
+    }
+
+    /**
+     * @test
+     */
+    public function instantiating_with_proxy_attribute_normalizes_to_underlying_object(): void
+    {
+        $object = ProxyContactFactory::createOne([
+            'category' => proxy(new StandardCategory('name')),
+        ]);
+
+        $this->assertInstanceOf(StandardCategory::class, $object->getCategory());
+    }
+
+    protected function tearDown(): void
+    {
+        // neutralize custom configuration added in some tests
+        UnitTestConfig::configure();
+        Configuration::boot(UnitTestConfig::build());
     }
 }


### PR DESCRIPTION
Here are some test backported from `Unit\FactoryTest` which were creating errors with foundry 2.x code

## FactoryTest
- [x] `can_register_custom_faker()`
- [x] `can_use_arrays_for_attribute_values()`
- [x] `can_register_default_instantiator()`
- [x] `instantiating_with_proxy_attribute_normalizes_to_underlying_object()`
- [x] `instantiating_with_factory_attribute_instantiates_the_factory()`
- [x] ~`can_create_object()`~ not useful test in 2.x
- [x] ~`can_add_after_persist_events()`~ After persist event should not be called in unit test (?)