### PR TITLE
feat: improve LazyValue

### DIFF
--- a/src/LazyValue.php
+++ b/src/LazyValue.php
@@ -41,6 +41,14 @@ final class LazyValue
 
         $value = ($this->factory)();
 
+        if ($value instanceof self) {
+            $value = ($value)();
+        }
+
+        if (\is_array($value)) {
+            $value = self::normalizeArray($value);
+        }
+
         if ($this->memoize) {
             return $this->memoizedValue = $value;
         }
@@ -56,5 +64,20 @@ final class LazyValue
     public static function memoize(callable $factory): self
     {
         return new self($factory, true);
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     * @return array<array-key, mixed>
+     */
+    private static function normalizeArray(array $value): array
+    {
+        \array_walk_recursive($value, static function(mixed &$v): void {
+            if ($v instanceof self) {
+                $v = $v();
+            }
+        });
+
+        return $value;
     }
 }

--- a/tests/Unit/LazyValueTest.php
+++ b/tests/Unit/LazyValueTest.php
@@ -13,6 +13,8 @@ namespace Zenstruck\Foundry\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 
+use Zenstruck\Foundry\LazyValue;
+
 use function Zenstruck\Foundry\lazy;
 use function Zenstruck\Foundry\memoize;
 
@@ -39,5 +41,36 @@ final class LazyValueTest extends TestCase
         $value = memoize(fn() => new \stdClass());
 
         $this->assertSame($value(), $value());
+    }
+
+    /**
+     * @test
+     */
+    public function can_handle_nested_lazy_values(): void
+    {
+        $value = LazyValue::new(LazyValue::new(LazyValue::new(fn() => LazyValue::new(fn() => 'foo'))));
+
+        $this->assertSame('foo', $value());
+    }
+
+    /**
+     * @test
+     */
+    public function can_handle_array_with_lazy_values(): void
+    {
+        $value = LazyValue::new(function() {
+            return [
+                5,
+                LazyValue::new(fn() => 'foo'),
+                6,
+                'foo' => [
+                    'bar' => 7,
+                    'baz' => LazyValue::new(fn() => 'foo'),
+                ],
+                [8, LazyValue::new(fn() => 'foo')],
+            ];
+        });
+
+        $this->assertSame([5, 'foo', 6, 'foo' => ['bar' => 7, 'baz' => 'foo'], [8, 'foo']], $value());
     }
 }


### PR DESCRIPTION
fixes some tests backported from 1.x which were creating errors with foundry 2.x code

## LazyValue
- [x] `LazyValueTest::can_handle_nested_lazy_values()`
- [x] `LazyValueTest::can_handle_array_with_lazy_values()`