### PR TITLE
feat: Factory::repository() should throw when persistence disabled

### DIFF
--- a/src/Exception/PersistenceDisabled.php
+++ b/src/Exception/PersistenceDisabled.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Exception;
+
+final class PersistenceDisabled extends \LogicException
+{
+}


### PR DESCRIPTION
This brings feature parity between foundry 1.x and 2.x towards behavior when persistence is disabled