### PR TITLE
feat: an array could be passed for a OneToMany relation

### DIFF
--- a/tests/Integration/ORM/EntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/EntityFactoryRelationshipTest.php
@@ -175,6 +175,25 @@ class EntityFactoryRelationshipTest extends KernelTestCase
     /**
      * @test
      */
+    public function inverse_one_to_many_relationship(): void
+    {
+        $this->categoryFactory()::assert()->count(0);
+        $this->contactFactory()::assert()->count(0);
+
+        $this->categoryFactory()->create([
+            'contacts' => [
+                $this->contactFactory(),
+                $this->contactFactory()->create(),
+            ],
+        ]);
+
+        $this->categoryFactory()::assert()->count(1);
+        $this->contactFactory()::assert()->count(2);
+    }
+
+    /**
+     * @test
+     */
     public function one_to_one_inverse(): void
     {
         $this->markTestSkipped('Not supported. Should it be?');


### PR DESCRIPTION
Here is a failing test case for a complex situation: foundry 2 does not handle well `OneToMany` relationships when an array is passed instead of a `FactoryCollection`