### PR TITLE
fix: accessing property in proxy after modification should not throw error

### DIFF
--- a/tests/Fixture/Model/GenericModel.php
+++ b/tests/Fixture/Model/GenericModel.php
@@ -43,8 +43,9 @@ abstract class GenericModel
         return $this->prop1;
     }
 
-    public function setProp1(string $prop1): void
+    public function setProp1(string $prop1): string
     {
         $this->prop1 = $prop1;
+        return $this->getProp1();
     }
 }

--- a/tests/Integration/ORM/GenericEntityProxyFactoryTest.php
+++ b/tests/Integration/ORM/GenericEntityProxyFactoryTest.php
@@ -23,6 +23,16 @@ final class GenericEntityProxyFactoryTest extends GenericProxyFactoryTestCase
 {
     use RequiresORM;
 
+    /**
+     * @test
+     */
+    public function test_modifier_which_calls_other_internal_method(): void
+    {
+        $object = $this->factory()->create();
+        $object->setProp1('foo');
+        $object->_save();
+    }
+
     protected function factory(): PersistentProxyObjectFactory
     {
         return GenericProxyEntityFactory::new();


### PR DESCRIPTION
here is a failing test case

this test produces the following error:
```
1) Zenstruck\Foundry\Tests\Integration\ORM\GenericEntityProxyFactoryTest::test_something
RuntimeException: Cannot auto refresh "Zenstruck\Foundry\Tests\Fixture\Entity\GenericEntity" as there are unsaved changes. Be sure to call ->_save() or disable auto refreshing (see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#auto-refresh for details).

/home/nikophil/works/zenstruck/foundry-next/src/Persistence/PersistenceManager.php:218
/home/nikophil/works/zenstruck/foundry-next/src/Persistence/IsProxy.php:68
/home/nikophil/works/zenstruck/foundry-next/src/Persistence/IsProxy.php:113
/home/nikophil/works/zenstruck/foundry-next/tests/Integration/ORM/GenericEntityProxyFactoryTest.php:33
```