### PR TITLE
feat: handle when an entity have two relationships to the same entity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "bamarni-bin": {
             "target-directory": "bin/tools",
             "bin-links": true,
-            "forward-command": false
+            "forward-command": true
         }
     },
     "minimum-stability": "dev",

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -183,16 +183,22 @@ abstract class Factory
      */
     protected function normalizeParameters(array $parameters): array
     {
-        return \array_map($this->normalizeParameter(...), $parameters);
+        return array_combine(
+            array_keys($parameters),
+            \array_map($this->normalizeParameter(...), array_keys($parameters), $parameters)
+        );
     }
 
     /**
      * @internal
      */
-    protected function normalizeParameter(mixed $value): mixed
+    protected function normalizeParameter(string $field, mixed $value): mixed
     {
         if (\is_array($value)) {
-            return \array_map($this->normalizeParameter(...), $value);
+            return array_combine(
+                array_keys($value),
+                \array_map($this->normalizeParameter(...), array_fill(0, count($value), $field), $value)
+            );
         }
 
         if ($value instanceof LazyValue) {
@@ -204,7 +210,7 @@ abstract class Factory
         }
 
         if ($value instanceof FactoryCollection) {
-            $value = $this->normalizeCollection($value);
+            $value = $this->normalizeCollection($field, $value);
         }
 
         return \is_object($value) ? $this->normalizeObject($value) : $value;
@@ -217,9 +223,9 @@ abstract class Factory
      *
      * @return self<mixed>[]
      */
-    protected function normalizeCollection(FactoryCollection $collection): array
+    protected function normalizeCollection(string $field, FactoryCollection $collection): array
     {
-        return \array_map(fn(Factory $f) => $this->normalizeParameter($f), $collection->all());
+        return \array_map(fn(Factory $f) => $this->normalizeParameter($field, $f), $collection->all());
     }
 
     /**

--- a/src/Persistence/PersistenceManager.php
+++ b/src/Persistence/PersistenceManager.php
@@ -297,12 +297,12 @@ final class PersistenceManager
      * @param class-string $parent
      * @param class-string $child
      */
-    public function relationshipMetadata(string $parent, string $child): ?RelationshipMetadata
+    public function relationshipMetadata(string $parent, string $child, string $field): ?RelationshipMetadata
     {
         $parent = unproxy($parent);
         $child = unproxy($child);
 
-        return $this->strategyFor($parent)->relationshipMetadata($parent, $child);
+        return $this->strategyFor($parent)->relationshipMetadata($parent, $child, $field);
     }
 
     /**

--- a/src/Persistence/PersistenceStrategy.php
+++ b/src/Persistence/PersistenceStrategy.php
@@ -65,7 +65,7 @@ abstract class PersistenceStrategy
      * @param class-string $parent
      * @param class-string $child
      */
-    public function relationshipMetadata(string $parent, string $child): ?RelationshipMetadata
+    public function relationshipMetadata(string $parent, string $child, string $field): ?RelationshipMetadata
     {
         return null;
     }

--- a/tests/Fixture/Entity/Category.php
+++ b/tests/Fixture/Entity/Category.php
@@ -25,6 +25,9 @@ abstract class Category extends Base
     /** @var Collection<int,Contact> */
     protected Collection $contacts;
 
+    /** @var Collection<int,Contact> */
+    protected Collection $secondaryContacts;
+
     #[ORM\Column(length: 255)]
     private string $name;
 
@@ -32,6 +35,7 @@ abstract class Category extends Base
     {
         $this->name = $name;
         $this->contacts = new ArrayCollection();
+        $this->secondaryContacts = new ArrayCollection();
     }
 
     public function getName(): ?string
@@ -39,7 +43,7 @@ abstract class Category extends Base
         return $this->name;
     }
 
-    public function setName(string $name): self
+    public function setName(string $name): static
     {
         $this->name = $name;
 
@@ -67,6 +71,31 @@ abstract class Category extends Base
     public function removeContact(Contact $contact): static
     {
         $this->contacts->removeElement($contact);
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int,Contact>
+     */
+    public function getSecondaryContacts(): Collection
+    {
+        return $this->secondaryContacts;
+    }
+
+    public function addSecondaryContact(Contact $secondaryContact): static
+    {
+        if (!$this->secondaryContacts->contains($secondaryContact)) {
+            $this->secondaryContacts->add($secondaryContact);
+            $secondaryContact->setSecondaryCategory($this);
+        }
+
+        return $this;
+    }
+
+    public function removeSecondaryContact(Contact $secondaryContact): static
+    {
+        $this->secondaryContacts->removeElement($secondaryContact);
 
         return $this;
     }

--- a/tests/Fixture/Entity/Category/CascadeCategory.php
+++ b/tests/Fixture/Entity/Category/CascadeCategory.php
@@ -24,4 +24,7 @@ class CascadeCategory extends Category
 {
     #[ORM\OneToMany(mappedBy: 'category', targetEntity: CascadeContact::class, cascade: ['persist', 'remove'])]
     protected Collection $contacts;
+
+    #[ORM\OneToMany(mappedBy: 'secondaryCategory', targetEntity: CascadeContact::class, cascade: ['persist', 'remove'])]
+    protected Collection $secondaryContacts;
 }

--- a/tests/Fixture/Entity/Category/StandardCategory.php
+++ b/tests/Fixture/Entity/Category/StandardCategory.php
@@ -24,4 +24,7 @@ class StandardCategory extends Category
 {
     #[ORM\OneToMany(mappedBy: 'category', targetEntity: StandardContact::class)]
     protected Collection $contacts;
+
+    #[ORM\OneToMany(mappedBy: 'secondaryCategory', targetEntity: StandardContact::class)]
+    protected Collection $secondaryContacts;
 }

--- a/tests/Fixture/Entity/Contact.php
+++ b/tests/Fixture/Entity/Contact.php
@@ -22,7 +22,7 @@ use Zenstruck\Foundry\Tests\Fixture\Model\Base;
 #[ORM\MappedSuperclass]
 abstract class Contact extends Base
 {
-    protected Category $category;
+    protected Category|null $category = null;
 
     protected Category|null $secondaryCategory = null;
 
@@ -37,10 +37,10 @@ abstract class Contact extends Base
     #[ORM\Column(length: 255)]
     private string $name;
 
-    public function __construct(string $name, Category $category, Address $address)
+    public function __construct(string $name/*, Category $category*/, Address $address)
     {
         $this->name = $name;
-        $this->category = $category;
+//        $this->category = $category;
         $this->address = $address;
         $this->tags = new ArrayCollection();
         $this->secondaryTags = new ArrayCollection();
@@ -58,12 +58,12 @@ abstract class Contact extends Base
         return $this;
     }
 
-    public function getCategory(): Category
+    public function getCategory(): ?Category
     {
         return $this->category;
     }
 
-    public function setCategory(Category $category): static
+    public function setCategory(?Category $category): static
     {
         $this->category = $category;
 

--- a/tests/Fixture/Entity/Contact.php
+++ b/tests/Fixture/Entity/Contact.php
@@ -37,10 +37,9 @@ abstract class Contact extends Base
     #[ORM\Column(length: 255)]
     private string $name;
 
-    public function __construct(string $name/*, Category $category*/, Address $address)
+    public function __construct(string $name, Address $address)
     {
         $this->name = $name;
-//        $this->category = $category;
         $this->address = $address;
         $this->tags = new ArrayCollection();
         $this->secondaryTags = new ArrayCollection();

--- a/tests/Fixture/Entity/Contact.php
+++ b/tests/Fixture/Entity/Contact.php
@@ -24,8 +24,13 @@ abstract class Contact extends Base
 {
     protected Category $category;
 
+    protected Category|null $secondaryCategory = null;
+
     /** @var Collection<int,Tag> */
     protected Collection $tags;
+
+    /** @var Collection<int,Tag> */
+    protected Collection $secondaryTags;
 
     protected Address $address;
 
@@ -38,6 +43,7 @@ abstract class Contact extends Base
         $this->category = $category;
         $this->address = $address;
         $this->tags = new ArrayCollection();
+        $this->secondaryTags = new ArrayCollection();
     }
 
     public function getName(): ?string
@@ -64,6 +70,16 @@ abstract class Contact extends Base
         return $this;
     }
 
+    public function getSecondaryCategory(): ?Category
+    {
+        return $this->secondaryCategory;
+    }
+
+    public function setSecondaryCategory(?Category $secondaryCategory): void
+    {
+        $this->secondaryCategory = $secondaryCategory;
+    }
+
     /**
      * @return Collection<int,Tag>
      */
@@ -86,6 +102,28 @@ abstract class Contact extends Base
         $this->tags->removeElement($tag);
 
         return $this;
+    }
+
+    /**
+     * @return Collection<int,Tag>
+     */
+    public function getSecondaryTags(): Collection
+    {
+        return $this->secondaryTags;
+    }
+
+    public function addSecondaryTag(Tag $secondaryTag): void
+    {
+        if (!$this->secondaryTags->contains($secondaryTag)) {
+            $this->secondaryTags[] = $secondaryTag;
+        }
+    }
+
+    public function removeSecondaryTag(Tag $tag): void
+    {
+        if ($this->tags->contains($tag)) {
+            $this->tags->removeElement($tag);
+        }
     }
 
     public function getAddress(): Address

--- a/tests/Fixture/Entity/Contact/CascadeContact.php
+++ b/tests/Fixture/Entity/Contact/CascadeContact.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Address;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Address\CascadeAddress;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Category;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Category\CascadeCategory;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Tag\CascadeTag;
 
@@ -29,8 +30,15 @@ class CascadeContact extends Contact
     #[ORM\JoinColumn(nullable: false)]
     protected Category $category;
 
+    #[ORM\ManyToOne(targetEntity: CascadeCategory::class, cascade: ['persist', 'remove'], inversedBy: 'secondaryContacts')]
+    protected Category|null $secondaryCategory = null;
+
     #[ORM\ManyToMany(targetEntity: CascadeTag::class, inversedBy: 'contacts', cascade: ['persist', 'remove'])]
     protected Collection $tags;
+
+    #[ORM\ManyToMany(targetEntity: CascadeTag::class, inversedBy: 'secondaryContacts', cascade: ['persist', 'remove'])]
+    #[ORM\JoinTable(name: 'category_tag_cascade_secondary')]
+    protected Collection $secondaryTags;
 
     #[ORM\OneToOne(targetEntity: CascadeAddress::class, cascade: ['persist', 'remove'])]
     #[ORM\JoinColumn(nullable: false)]

--- a/tests/Fixture/Entity/Contact/CascadeContact.php
+++ b/tests/Fixture/Entity/Contact/CascadeContact.php
@@ -27,8 +27,8 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Tag\CascadeTag;
 class CascadeContact extends Contact
 {
     #[ORM\ManyToOne(targetEntity: Category\CascadeCategory::class, cascade: ['persist', 'remove'], inversedBy: 'contacts')]
-    #[ORM\JoinColumn(nullable: false)]
-    protected Category $category;
+    #[ORM\JoinColumn(nullable: true)]
+    protected Category|null $category = null;
 
     #[ORM\ManyToOne(targetEntity: CascadeCategory::class, cascade: ['persist', 'remove'], inversedBy: 'secondaryContacts')]
     protected Category|null $secondaryCategory = null;

--- a/tests/Fixture/Entity/Contact/StandardContact.php
+++ b/tests/Fixture/Entity/Contact/StandardContact.php
@@ -30,8 +30,15 @@ class StandardContact extends Contact
     #[ORM\JoinColumn(nullable: false)]
     protected Category $category;
 
+    #[ORM\ManyToOne(targetEntity: StandardCategory::class, inversedBy: 'secondaryContacts')]
+    protected Category|null $secondaryCategory = null;
+
     #[ORM\ManyToMany(targetEntity: StandardTag::class, inversedBy: 'contacts')]
     protected Collection $tags;
+
+    #[ORM\ManyToMany(targetEntity: StandardTag::class, inversedBy: 'secondaryContacts')]
+    #[ORM\JoinTable(name: 'category_tag_standard_secondary')]
+    protected Collection $secondaryTags;
 
     #[ORM\OneToOne(targetEntity: StandardAddress::class)]
     #[ORM\JoinColumn(nullable: false)]

--- a/tests/Fixture/Entity/Contact/StandardContact.php
+++ b/tests/Fixture/Entity/Contact/StandardContact.php
@@ -27,8 +27,8 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Tag\StandardTag;
 class StandardContact extends Contact
 {
     #[ORM\ManyToOne(targetEntity: StandardCategory::class, inversedBy: 'contacts')]
-    #[ORM\JoinColumn(nullable: false)]
-    protected Category $category;
+    #[ORM\JoinColumn(nullable: true)]
+    protected Category|null $category = null;
 
     #[ORM\ManyToOne(targetEntity: StandardCategory::class, inversedBy: 'secondaryContacts')]
     protected Category|null $secondaryCategory = null;

--- a/tests/Fixture/Entity/EdgeCases/MultipleMandatoryRelationshipToSameEntity/InversedSideEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/MultipleMandatoryRelationshipToSameEntity/InversedSideEntity.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\MultipleMandatoryRelationshipToSameEntity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+#[ORM\Entity]
+final class InversedSideEntity extends Base
+{
+    /** @var Collection<int,OwningSideEntity> */
+    #[ORM\OneToMany(mappedBy: 'main', targetEntity: OwningSideEntity::class, cascade: ['persist', 'remove'])]
+    private Collection $mainRelations;
+
+    /** @var Collection<int,OwningSideEntity> */
+    #[ORM\OneToMany(mappedBy: 'secondary', targetEntity: OwningSideEntity::class, cascade: ['persist', 'remove'])]
+    private Collection $secondaryRelations;
+
+    public function __construct()
+    {
+        $this->mainRelations = new ArrayCollection();
+        $this->secondaryRelations = new ArrayCollection();
+    }
+
+    /**
+     * @return Collection<int,OwningSideEntity>
+     */
+    public function getMainRelations(): Collection
+    {
+        return $this->mainRelations;
+    }
+
+    public function addMainRelation(OwningSideEntity $mainRelation): static
+    {
+        if (!$this->mainRelations->contains($mainRelation)) {
+            $this->mainRelations->add($mainRelation);
+            $mainRelation->setMain($this);
+        }
+
+        return $this;
+    }
+
+    public function removeMainRelation(OwningSideEntity $mainRelation): static
+    {
+        $this->mainRelations->removeElement($mainRelation);
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int,OwningSideEntity>
+     */
+    public function getSecondaryRelations(): Collection
+    {
+        return $this->secondaryRelations;
+    }
+
+    public function addSecondaryRelation(OwningSideEntity $secondaryRelation): static
+    {
+        if (!$this->secondaryRelations->contains($secondaryRelation)) {
+            $this->secondaryRelations->add($secondaryRelation);
+            $secondaryRelation->setSecondary($this);
+        }
+
+        return $this;
+    }
+
+    public function removeSecondaryRelation(OwningSideEntity $secondaryRelation): static
+    {
+        $this->secondaryRelations->removeElement($secondaryRelation);
+
+        return $this;
+    }
+}

--- a/tests/Fixture/Entity/EdgeCases/MultipleMandatoryRelationshipToSameEntity/OwningSideEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/MultipleMandatoryRelationshipToSameEntity/OwningSideEntity.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\MultipleMandatoryRelationshipToSameEntity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+#[ORM\Entity]
+final class OwningSideEntity extends Base
+{
+    public function __construct(
+        #[ORM\ManyToOne(targetEntity: InversedSideEntity::class, cascade: ['persist', 'remove'], inversedBy: 'mainRelations')]
+        private InversedSideEntity $main,
+        #[ORM\ManyToOne(targetEntity: InversedSideEntity::class, cascade: ['persist', 'remove'], inversedBy: 'secondaryRelations')]
+        private InversedSideEntity $secondary,
+    ) {
+    }
+
+    public function getMain(): InversedSideEntity
+    {
+        return $this->main;
+    }
+
+    public function setMain(InversedSideEntity $main): static
+    {
+        $this->main = $main;
+
+        return $this;
+    }
+
+    public function getSecondary(): InversedSideEntity
+    {
+        return $this->secondary;
+    }
+
+    public function setSecondary(InversedSideEntity $secondary): void
+    {
+        $this->secondary = $secondary;
+    }
+}

--- a/tests/Fixture/Entity/EdgeCases/RichDomainMandatoryRelationship/InversedSideEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/RichDomainMandatoryRelationship/InversedSideEntity.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RichDomainMandatoryRelationship;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+#[ORM\Entity()]
+#[ORM\Table(name: 'rich_domain_mandatory_relationship_inversed_side_entity')]
+final class InversedSideEntity extends Base
+{
+    /** @var Collection<int,OwningSideEntity> */
+    #[ORM\OneToMany(mappedBy: 'main', targetEntity: OwningSideEntity::class, cascade: ['persist', 'remove'])]
+    private Collection $relations;
+
+    public function __construct()
+    {
+        $this->relations = new ArrayCollection();
+    }
+
+    /**
+     * @return Collection<int,OwningSideEntity>
+     */
+    public function getRelations(): Collection
+    {
+        return $this->relations;
+    }
+
+    public function addRelation(OwningSideEntity $relation): static
+    {
+        if (!$this->relations->contains($relation)) {
+            $this->relations->add($relation);
+        }
+
+        return $this;
+    }
+
+    public function removeRelation(OwningSideEntity $relation): static
+    {
+        $this->relations->removeElement($relation);
+
+        return $this;
+    }
+}

--- a/tests/Fixture/Entity/EdgeCases/RichDomainMandatoryRelationship/OwningSideEntity.php
+++ b/tests/Fixture/Entity/EdgeCases/RichDomainMandatoryRelationship/OwningSideEntity.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RichDomainMandatoryRelationship;
+
+use Doctrine\ORM\Mapping as ORM;
+use Zenstruck\Foundry\Tests\Fixture\Model\Base;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'rich_domain_mandatory_relationship_owning_side_entity')]
+final class OwningSideEntity extends Base
+{
+    public function __construct(
+        #[ORM\ManyToOne(targetEntity: InversedSideEntity::class, cascade: ['persist', 'remove'], inversedBy: 'mainRelations')]
+        private InversedSideEntity $main,
+    ) {
+        $main->addRelation($this);
+    }
+
+    public function getMain(): InversedSideEntity
+    {
+        return $this->main;
+    }
+}

--- a/tests/Fixture/Entity/Tag.php
+++ b/tests/Fixture/Entity/Tag.php
@@ -25,6 +25,9 @@ abstract class Tag extends Base
     /** @var Collection<int,Contact> */
     protected Collection $contacts;
 
+    /** @var Collection<int,Contact> */
+    protected Collection $secondaryContacts;
+
     #[ORM\Column(length: 255)]
     private string $name;
 
@@ -32,6 +35,7 @@ abstract class Tag extends Base
     {
         $this->name = $name;
         $this->contacts = new ArrayCollection();
+        $this->secondaryContacts = new ArrayCollection();
     }
 
     public function getName(): ?string
@@ -71,5 +75,29 @@ abstract class Tag extends Base
         }
 
         return $this;
+    }
+
+    /**
+     * @return Collection<int,Contact>
+     */
+    public function getSecondaryContacts(): Collection
+    {
+        return $this->secondaryContacts;
+    }
+
+    public function addSecondaryContact(Contact $secondaryContact): void
+    {
+        if (!$this->secondaryContacts->contains($secondaryContact)) {
+            $this->secondaryContacts[] = $secondaryContact;
+            $secondaryContact->addSecondaryTag($this);
+        }
+    }
+
+    public function removeSecondaryContact(Contact $secondaryContact): void
+    {
+        if ($this->secondaryContacts->contains($secondaryContact)) {
+            $this->secondaryContacts->removeElement($secondaryContact);
+            $secondaryContact->removeSecondaryTag($this);
+        }
     }
 }

--- a/tests/Fixture/Entity/Tag/CascadeTag.php
+++ b/tests/Fixture/Entity/Tag/CascadeTag.php
@@ -14,6 +14,7 @@ namespace Zenstruck\Foundry\Tests\Fixture\Entity\Tag;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Contact\CascadeContact;
+use Zenstruck\Foundry\Tests\Fixture\Entity\Contact\StandardContact;
 use Zenstruck\Foundry\Tests\Fixture\Entity\Tag;
 
 /**
@@ -24,4 +25,7 @@ class CascadeTag extends Tag
 {
     #[ORM\ManyToMany(targetEntity: CascadeContact::class, mappedBy: 'tags', cascade: ['persist', 'remove'])]
     protected Collection $contacts;
+
+    #[ORM\ManyToMany(targetEntity: CascadeContact::class, mappedBy: 'secondaryTags', cascade: ['persist', 'remove'])]
+    protected Collection $secondaryContacts;
 }

--- a/tests/Fixture/Entity/Tag/StandardTag.php
+++ b/tests/Fixture/Entity/Tag/StandardTag.php
@@ -24,4 +24,7 @@ class StandardTag extends Tag
 {
     #[ORM\ManyToMany(targetEntity: StandardContact::class, mappedBy: 'tags')]
     protected Collection $contacts;
+
+    #[ORM\ManyToMany(targetEntity: StandardContact::class, mappedBy: 'secondaryTags')]
+    protected Collection $secondaryContacts;
 }

--- a/tests/Fixture/Factories/Entity/Contact/CascadeContactFactory.php
+++ b/tests/Fixture/Factories/Entity/Contact/CascadeContactFactory.php
@@ -32,7 +32,7 @@ final class CascadeContactFactory extends PersistentObjectFactory
     {
         return [
             'name' => self::faker()->word(),
-            'category' => CascadeCategoryFactory::new(),
+//            'category' => CascadeCategoryFactory::new(),
             'address' => CascadeAddressFactory::new(),
         ];
     }

--- a/tests/Fixture/Factories/Entity/Contact/ProxyContactFactory.php
+++ b/tests/Fixture/Factories/Entity/Contact/ProxyContactFactory.php
@@ -32,7 +32,7 @@ final class ProxyContactFactory extends PersistentProxyObjectFactory
     {
         return [
             'name' => self::faker()->word(),
-            'category' => ProxyCategoryFactory::new(),
+//            'category' => ProxyCategoryFactory::new(),
             'address' => ProxyAddressFactory::new(),
         ];
     }

--- a/tests/Fixture/Factories/Entity/Contact/StandardContactFactory.php
+++ b/tests/Fixture/Factories/Entity/Contact/StandardContactFactory.php
@@ -32,7 +32,7 @@ final class StandardContactFactory extends PersistentObjectFactory
     {
         return [
             'name' => self::faker()->word(),
-            'category' => StandardCategoryFactory::new(),
+//            'category' => StandardCategoryFactory::new(),
             'address' => StandardAddressFactory::new(),
         ];
     }

--- a/tests/Fixture/Factories/Entity/EdgeCases/MultipleMandatoryRelationshipToSameEntity/InversedSideEntityFactory.php
+++ b/tests/Fixture/Factories/Entity/EdgeCases/MultipleMandatoryRelationshipToSameEntity/InversedSideEntityFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Factories\Entity\EdgeCases\MultipleMandatoryRelationshipToSameEntity;
+
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\MultipleMandatoryRelationshipToSameEntity\InversedSideEntity;
+
+/**
+ * @extends PersistentObjectFactory<InversedSideEntity>
+ */
+final class InversedSideEntityFactory extends PersistentObjectFactory
+{
+    public static function class(): string
+    {
+        return InversedSideEntity::class;
+    }
+
+    protected function defaults(): array|callable
+    {
+        return [];
+    }
+}

--- a/tests/Fixture/Factories/Entity/EdgeCases/MultipleMandatoryRelationshipToSameEntity/OwningSideEntityFactory.php
+++ b/tests/Fixture/Factories/Entity/EdgeCases/MultipleMandatoryRelationshipToSameEntity/OwningSideEntityFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Factories\Entity\EdgeCases\MultipleMandatoryRelationshipToSameEntity;
+
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\MultipleMandatoryRelationshipToSameEntity\OwningSideEntity;
+
+/**
+ * @extends PersistentObjectFactory<OwningSideEntity>
+ */
+final class OwningSideEntityFactory extends PersistentObjectFactory
+{
+    public static function class(): string
+    {
+        return OwningSideEntity::class;
+    }
+
+    protected function defaults(): array|callable
+    {
+        return [
+            'main' => InversedSideEntityFactory::new(),
+            'secondary' => InversedSideEntityFactory::new(),
+        ];
+    }
+}

--- a/tests/Fixture/Factories/Entity/EdgeCases/RichDomainMandatoryRelationship/InversedSideEntityFactory.php
+++ b/tests/Fixture/Factories/Entity/EdgeCases/RichDomainMandatoryRelationship/InversedSideEntityFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Factories\Entity\EdgeCases\RichDomainMandatoryRelationship;
+
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RichDomainMandatoryRelationship\InversedSideEntity;
+
+/**
+ * @extends PersistentObjectFactory<InversedSideEntity>
+ */
+final class InversedSideEntityFactory extends PersistentObjectFactory
+{
+    public static function class(): string
+    {
+        return InversedSideEntity::class;
+    }
+
+    protected function defaults(): array|callable
+    {
+        return [];
+    }
+}

--- a/tests/Fixture/Factories/Entity/EdgeCases/RichDomainMandatoryRelationship/OwningSideEntityFactory.php
+++ b/tests/Fixture/Factories/Entity/EdgeCases/RichDomainMandatoryRelationship/OwningSideEntityFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/foundry package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Foundry\Tests\Fixture\Factories\Entity\EdgeCases\RichDomainMandatoryRelationship;
+
+use Zenstruck\Foundry\Persistence\PersistentObjectFactory;
+use Zenstruck\Foundry\Tests\Fixture\Entity\EdgeCases\RichDomainMandatoryRelationship\OwningSideEntity;
+
+/**
+ * @extends PersistentObjectFactory<OwningSideEntity>
+ */
+final class OwningSideEntityFactory extends PersistentObjectFactory
+{
+    public static function class(): string
+    {
+        return OwningSideEntity::class;
+    }
+
+    protected function defaults(): array|callable
+    {
+        return [
+            'main' => InversedSideEntityFactory::new(),
+        ];
+    }
+}

--- a/tests/Integration/ORM/CascadeEntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/CascadeEntityFactoryRelationshipTest.php
@@ -35,10 +35,11 @@ final class CascadeEntityFactoryRelationshipTest extends EntityFactoryRelationsh
             })
             ->create([
                 'tags' => $this->tagFactory()->many(3),
+                'category' => $this->categoryFactory()
             ])
         ;
 
-        $this->assertNotNull($contact->getCategory()->id);
+        $this->assertNotNull($contact->getCategory()?->id);
         $this->assertNotNull($contact->getAddress()->id);
         $this->assertCount(3, $contact->getTags());
 

--- a/tests/Integration/ORM/EntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/EntityFactoryRelationshipTest.php
@@ -23,6 +23,8 @@ use Zenstruck\Foundry\Tests\Fixture\Entity\Tag;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Address\StandardAddressFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Category\StandardCategoryFactory;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Contact\StandardContactFactory;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\EdgeCases\MultipleMandatoryRelationshipToSameEntity;
+use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\EdgeCases\RichDomainMandatoryRelationship;
 use Zenstruck\Foundry\Tests\Fixture\Factories\Entity\Tag\StandardTagFactory;
 use Zenstruck\Foundry\Tests\Integration\RequiresORM;
 
@@ -282,6 +284,42 @@ class EntityFactoryRelationshipTest extends KernelTestCase
         $this->assertCount(1, $category->getSecondaryContacts());
         $this->contactFactory()::assert()->count(2);
         $this->categoryFactory()::assert()->count(1);
+    }
+
+    /**
+     * @test
+     */
+    public function inversed_multiple_mandatory_relationship_to_same_entity(): void
+    {
+        $this->markTestIncomplete('fixme! 🙏');
+
+        // @phpstan-ignore-next-line
+        $inversedSideEntity = MultipleMandatoryRelationshipToSameEntity\InversedSideEntityFactory::createOne([
+            'mainRelations' => MultipleMandatoryRelationshipToSameEntity\OwningSideEntityFactory::new()->many(2),
+            'secondaryRelations' => MultipleMandatoryRelationshipToSameEntity\OwningSideEntityFactory::new()->many(2),
+        ]);
+
+        $this->assertCount(2, $inversedSideEntity->getMainRelations());
+        $this->assertCount(2, $inversedSideEntity->getSecondaryRelations());
+        MultipleMandatoryRelationshipToSameEntity\OwningSideEntityFactory::assert()->count(4);
+        MultipleMandatoryRelationshipToSameEntity\InversedSideEntityFactory::assert()->count(1);
+    }
+
+    /**
+     * @test
+     */
+    public function inversed_mandatory_relationship_in_rich_domain(): void
+    {
+        $this->markTestIncomplete('fixme! 🙏');
+
+        // @phpstan-ignore-next-line
+        $inversedSideEntity = RichDomainMandatoryRelationship\InversedSideEntityFactory::createOne([
+            'main' => RichDomainMandatoryRelationship\OwningSideEntityFactory::new()->many(2),
+        ]);
+
+        $this->assertCount(2, $inversedSideEntity->getRelations());
+        RichDomainMandatoryRelationship\OwningSideEntityFactory::assert()->count(2);
+        RichDomainMandatoryRelationship\InversedSideEntityFactory::assert()->count(1);
     }
 
     /**

--- a/tests/Integration/ORM/EntityFactoryRelationshipTest.php
+++ b/tests/Integration/ORM/EntityFactoryRelationshipTest.php
@@ -200,6 +200,69 @@ class EntityFactoryRelationshipTest extends KernelTestCase
     }
 
     /**
+     * @test
+     */
+    public function one_to_many_with_two_relationships_same_entity(): void
+    {
+        $category = $this->categoryFactory()->create([
+            'contacts' => $this->contactFactory()->many(4),
+            'secondaryContacts' => $this->contactFactory()->many(4),
+        ]);
+
+        $this->assertCount(4, $category->getContacts());
+        $this->assertCount(4, $category->getSecondaryContacts());
+        $this->contactFactory()::assert()->count(8);
+        $this->categoryFactory()::assert()->count(1);
+    }
+
+    /**
+     * @test
+     */
+    public function inverse_many_to_many_with_two_relationships_same_entity(): void
+    {
+        $this->tagFactory()::assert()->count(0);
+
+        $tag = $this->tagFactory()->create([
+            'contacts' => $this->contactFactory()->many(3),
+            'secondaryContacts' => $this->contactFactory()->many(3),
+        ]);
+
+        $this->assertCount(3, $tag->getContacts());
+        $this->assertCount(3, $tag->getSecondaryContacts());
+        $this->tagFactory()::assert()->count(1);
+        $this->contactFactory()::assert()->count(6);
+    }
+
+    /**
+     * @test
+     */
+    public function can_use_adder_as_attributes(): void
+    {
+        $category = $this->categoryFactory()->create([
+            'addContact' => $this->contactFactory()->with(['name' => 'foo'])
+        ]);
+
+        self::assertCount(1, $category->getContacts());
+        self::assertSame('foo', $category->getContacts()[0]->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function one_to_many_with_two_relationships_same_entity_and_adders(): void
+    {
+        $category = $this->categoryFactory()->create([
+            'addContact' => $this->contactFactory(),
+            'addSecondaryContact' => $this->contactFactory(),
+        ]);
+
+        $this->assertCount(1, $category->getContacts());
+        $this->assertCount(1, $category->getSecondaryContacts());
+        $this->contactFactory()::assert()->count(2);
+        $this->categoryFactory()::assert()->count(1);
+    }
+
+    /**
      * @return PersistentObjectFactory<Contact>
      */
     protected function contactFactory(): PersistentObjectFactory


### PR DESCRIPTION
I'm struggling with [this test](https://github.com/zenstruck/foundry/blob/1.x/tests/Functional/ORMModelFactoryTest.php#L94)

Actually, I managed to get feature parity with foundry 1, but I've discovered a bug (in foundry 1) and I don't know how to mitigate it, it is pretty complex.

in this test, if `Post::$category` has a default in `PostFactory` (something like `'category' => CategoryFactory::new()`) the  test fails.
It fails because foundry creates a new category for each `secondaryPosts.category` :shrug:

And in Foundry 2, the equivalent field (`Contact::$category`) is mandatory, so... we always have as many category created as new "secondary contact" created.

https://github.com/kbond/foundry-next/actions/runs/7775788405/job/21202156474?pr=17#step:6:66

I think a (complex) solution would be to check all relationships in `Contact` which targets `Category`, and hydrates it with the main category, only if the field is mandatory

I have mixed feelings towards this: I'm quite surprised that this bug has not been spotted, this is not really a strange case. On the other hand, because nobody yelled about it, I'm tempted to make `Contact::$category` nullable in Foundry tests 2 and... voilà! and maybe open an issue

I have separated the PR in two commits: in the second one, I only set `Contact::$category` nullable, which makes the tests pass, and hides the problem under the rug :innocent: 

WDYT?