### PR TITLE
fix: allow to get proxy's real object if it is modified

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "bamarni-bin": {
             "target-directory": "bin/tools",
             "bin-links": true,
-            "forward-command": false
+            "forward-command": true
         }
     },
     "minimum-stability": "dev",

--- a/src/Persistence/IsProxy.php
+++ b/src/Persistence/IsProxy.php
@@ -98,7 +98,11 @@ trait IsProxy
 
     public function _real(): object
     {
-        $this->_autoRefresh();
+        try {
+            // we don't want the auto-refresh mechanism to break "real" object retrieval
+            $this->_autoRefresh();
+        } catch (\Throwable) {
+        }
 
         return $this->initializeLazyObject();
     }

--- a/tests/Integration/Persistence/GenericProxyFactoryTestCase.php
+++ b/tests/Integration/Persistence/GenericProxyFactoryTestCase.php
@@ -220,6 +220,19 @@ abstract class GenericProxyFactoryTestCase extends GenericFactoryTestCase
     }
 
     /**
+     * @test
+     */
+    public function can_get_real_object_even_if_modified(): void
+    {
+        $object = $this->factory()->create();
+        $object->setProp1('foo');
+
+        self::assertInstanceOf(GenericModel::class, $real = $object->_real());
+        self::assertSame('foo', $real->getProp1());
+
+    }
+
+    /**
      * @return PersistentProxyObjectFactory<GenericModel>
      */
     abstract protected function factory(): PersistentProxyObjectFactory; // @phpstan-ignore-line


### PR DESCRIPTION
Hey, would you accept this PR? it fixes more or less all remaining problems in with Foundry's 1 test suite